### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://dev.azure.com/tt5429/f0232fd4-e44e-4386-99e9-868c3944d3d1/e3b39456-77ec-4aa0-a415-d2cb79d6799f/_apis/work/boardbadge/8e592311-46c2-4fd1-bf53-ebed3f02b5b5)](https://dev.azure.com/tt5429/f0232fd4-e44e-4386-99e9-868c3944d3d1/_boards/board/t/e3b39456-77ec-4aa0-a415-d2cb79d6799f/Microsoft.RequirementCategory)
 # Mycroft 
 
 ### Deployed at [mycroft.tanmoysg.com](http://mycroft.tanmoysg.com/)


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/tt5429/f0232fd4-e44e-4386-99e9-868c3944d3d1/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.